### PR TITLE
Fix the issue where XmlReader skips <sdnEntry/> node if it is placed right after the previous <sdnEntry/> node.

### DIFF
--- a/src/SdnListMonitor.Core/Service/Xml/SdnXmlDataProvider.cs
+++ b/src/SdnListMonitor.Core/Service/Xml/SdnXmlDataProvider.cs
@@ -71,13 +71,15 @@ namespace SdnListMonitor.Core.Service.Xml
 
         private async IAsyncEnumerable<ISdnEntry> ReadSdnEntriesAsync (XmlReader xmlReader)
         {
-            while (await xmlReader.ReadAsync ().ConfigureAwait (false))
+            while (!xmlReader.EOF)
             {
                 // Skip all the nodes that are not <sdnEntry/> as we are only interested in those.
-                if (!xmlReader.IsStartElement () || xmlReader.Name != SdnXmlEntry.SdnEntryNodeName)
+                if (!xmlReader.IsStartElement () || !string.Equals (xmlReader.Name, SdnXmlEntry.SdnEntryNodeName, StringComparison.Ordinal))
+                {
+                    await xmlReader.ReadAsync ().ConfigureAwait (false);
                     continue;
-
-                // Consider SDN.xml file malformed if we are unable to deserialize one of the <sdnList/> nodes.
+                }
+                //// Consider SDN.xml file malformed if we are unable to deserialize one of the <sdnList/> nodes.
                 if (!m_xmlSerializer.CanDeserialize (xmlReader))
                     throw new InvalidOperationException (Res.ErrorWhileRetrievingSdnList);
 

--- a/tests/SdnListMonitor.Core.Tests/Service/Xml/SdnXmlDataProviderTests.cs
+++ b/tests/SdnListMonitor.Core.Tests/Service/Xml/SdnXmlDataProviderTests.cs
@@ -50,6 +50,7 @@ namespace SdnListMonitor.Core.Tests.Service
             m_options.Value.XmlFilePath = Guid.NewGuid ().ToString ();
             var xmlReader = new Mock<XmlReader> ();
             xmlReader.Setup (self => self.ReadToDescendant (It.IsAny<string> ())).Returns (true);
+            xmlReader.Setup (self => self.EOF).Returns (true);
             var xmlReaderFactory = CreateXmlReaderFactory (xmlReader.Object);
             var sdnXmlDataProvider = new SdnXmlDataProvider (xmlReaderFactory, m_options);
 
@@ -69,6 +70,7 @@ namespace SdnListMonitor.Core.Tests.Service
             // Arrange
             var xmlReader = new Mock<XmlReader> ();
             xmlReader.Setup (self => self.ReadToDescendant (It.IsAny<string> ())).Returns (true);
+            xmlReader.Setup (self => self.EOF).Returns (true);
             var xmlReaderFactory = CreateXmlReaderFactory (xmlReader.Object);
             var sdnXmlDataProvider = new SdnXmlDataProvider (xmlReaderFactory, m_options);
 
@@ -135,11 +137,16 @@ namespace SdnListMonitor.Core.Tests.Service
         public async Task GetSdnEntriesAsync_WhenSdnListContainsSdnEntries_ShouldReturnSdnEntries ()
         {
             // Arrange
-            var expectedSdnEntries = new[] { new SdnXmlEntry { Uid = 1 }, new SdnXmlEntry { Uid = 2 }, new SdnXmlEntry { Uid = 3 } };
+            var expectedSdnEntries = new[] 
+                {
+                new SdnXmlEntry { Uid = 1 },
+                new SdnXmlEntry { Uid = 2 },
+                new SdnXmlEntry { Uid = 3 },
+                };
             var sdnListXml = CreateSdnListXElement (expectedSdnEntries);
-            var str = sdnListXml.ToString ();
-            var stream = CreateStreamFromString (str);
-            var xmlReader = XmlReader.Create (stream, new XmlReaderSettings { Async = true });
+            var stream = CreateStreamFromString (sdnListXml.ToString ());
+            var xmLReaderSettings = new XmlReaderSettings { Async = true, IgnoreComments = true, IgnoreWhitespace = true };
+            var xmlReader = XmlReader.Create (stream, xmLReaderSettings);
             var xmlReaderFactory = CreateXmlReaderFactory (xmlReader);
             var sdnXmlDataProvider = new SdnXmlDataProvider (xmlReaderFactory, m_options);
 
@@ -207,6 +214,7 @@ namespace SdnListMonitor.Core.Tests.Service
             // Arrange
             var xmlReader = new Mock<XmlReader> ();
             xmlReader.Setup (self => self.ReadToDescendant (It.IsAny<string> ())).Returns (true);
+            xmlReader.Setup (self => self.EOF).Returns (true);
             var disposableXmlReader = xmlReader.As<IDisposable> ();
             var xmlReaderFactory = CreateXmlReaderFactory (xmlReader.Object);
             var sdnXmlDataProvider = new SdnXmlDataProvider (xmlReaderFactory, m_options);


### PR DESCRIPTION
Fixed the issue where `XmlReader` skips `<sdnEntry/>` node if it is placed right after the previous `<sdnEntry/>` node.
Because `XmlSerializer` reads to the next node (in this case `<sdnEntry>`), the loop iteration ends,  `while (await xmlReader.ReadAsync())` skips the opening `<sdnEntry>` tag.

The following actions were applied to fix this:
- Read until the end of file.
- Only invoke `ReadAsync` if it is not `<sdnEntry>` opening tag.
- If it is `<sdnEntry>` opening tag, deserializer will deserialize it and move to the next node.

